### PR TITLE
Adding missing translations for the form labels

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,7 +10,9 @@ en:
     tax_cloud_api_login_and_key: API Login and Key
     taxcloud_api_login_id: Tax Cloud API Login ID
     taxcloud_api_key: Tax Cloud API Key
+    taxcloud_default_product_tic: Tax Cloud Product TIC
     taxcloud_shipping_tic: Tax Cloud Shipping TIC
+    taxcloud_usps_user_id: USPS User ID
     tax_cloud_tic: Tax Cloud TIC
     usps_user: USPS User ID
     usps_user_id: USPS API User ID


### PR DESCRIPTION
A couple of labels that were missed/mis-named.  Should fix #2 