### PR TITLE
Adds puma to Gemfile

### DIFF
--- a/spree_tax_cloud.gemspec
+++ b/spree_tax_cloud.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'generator_spec'
   s.add_development_dependency 'poltergeist'
   s.add_development_dependency 'pry'
+  s.add_development_dependency 'puma'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'sass-rails'
   s.add_development_dependency 'selenium-webdriver'


### PR DESCRIPTION
Puma is required to run Rails 5.2, the version of Rails installed
currently on a clean install.