### PR TITLE
Fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,10 @@ env:
     - SOLIDUS_BRANCH=v2.5 DB=postgres
     - SOLIDUS_BRANCH=v2.6 DB=postgres
     - SOLIDUS_BRANCH=v2.7 DB=postgres
+    - SOLIDUS_BRANCH=v2.8 DB=postgres
     - SOLIDUS_BRANCH=master DB=postgres
     - SOLIDUS_BRANCH=v2.5 DB=mysql
     - SOLIDUS_BRANCH=v2.6 DB=mysql
     - SOLIDUS_BRANCH=v2.7 DB=mysql
+    - SOLIDUS_BRANCH=v2.8 DB=mysql
     - SOLIDUS_BRANCH=master DB=mysql

--- a/Gemfile
+++ b/Gemfile
@@ -1,20 +1,19 @@
 source 'https://rubygems.org'
 
 branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
-gem "solidus", github: "solidusio/solidus", branch: branch
+gem "solidus", git: 'https://github.com/solidusio/solidus.git', branch: branch
 
 group :test do
-  if branch == 'master' || branch >= "v2.0"
-    gem "rails-controller-testing"
-  else
-    gem "rails_test_params_backport"
-  end
+  gem 'rails-controller-testing'
+  gem 'capybara-screenshot'
 end
 
 gem 'rake', '< 11.0'
-gem 'capybara-screenshot', group: :test
 
-gem 'pg'
-gem 'mysql2'
+if ENV['DB'] == 'mysql'
+  gem 'mysql2', '~> 0.4.10'
+else
+  gem 'pg', '~> 0.21'
+end
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
-gem "solidus", git: 'https://github.com/solidusio/solidus.git', branch: branch
+gem 'solidus', github: 'solidusio/solidus', branch: branch
 
 group :test do
   gem 'rails-controller-testing'

--- a/spec/features/checkout_spec.rb
+++ b/spec/features/checkout_spec.rb
@@ -286,8 +286,14 @@ describe 'Checkout', js: true do
     it 'TaxCloud Test Case 3, with item discount' do
       add_to_cart('Shirt')
 
-      fill_in 'order_coupon_code', with: 'AAAA'
-      click_button 'Update'
+      if Spree.solidus_gem_version >= Gem::Version.new('2.8.0')
+        fill_in 'coupon_code', with: 'AAAA'
+        click_button 'Apply Code'
+      else
+        fill_in 'order_coupon_code', with: 'AAAA'
+        click_button 'Update'
+      end
+
       expect(page).not_to have_content('The coupon code you entered doesn\'t exist.')
       expect(page).to have_content('The coupon code was successfully applied to your order.')
       click_button 'Checkout'
@@ -311,8 +317,14 @@ describe 'Checkout', js: true do
       add_to_cart('Shirt')
       add_to_cart('Shirt')
 
-      fill_in 'order_coupon_code', with: 'AAAA'
-      click_button 'Update'
+      if Spree.solidus_gem_version >= Gem::Version.new('2.8.0')
+        fill_in 'coupon_code', with: 'AAAA'
+        click_button 'Apply Code'
+      else
+        fill_in 'order_coupon_code', with: 'AAAA'
+        click_button 'Update'
+      end
+
       expect(page).not_to have_content('The coupon code you entered doesn\'t exist.')
       expect(page).to have_content('The coupon code was successfully applied to your order.')
       click_button 'Checkout'


### PR DESCRIPTION
This PR aims to get a green Travis build by doing the following:

* Replace `order_coupon_code` -> `coupon_code` (see commit's description for details)
* Gemfile maintenance (see commit's description for details)

It also adds [Solidus v2.8](https://github.com/solidusio/solidus/releases/tag/v2.8.0) to the build matrix :tada: