### PR TITLE
Fix grammar/syntax in checkout_spec

### DIFF
--- a/spec/features/checkout_spec.rb
+++ b/spec/features/checkout_spec.rb
@@ -108,7 +108,7 @@ describe 'Checkout', js: true do
     expect(page).not_to have_content(/Internal Server Error/i)
   end
 
-  it 'onlies calculate using tax cloud for orders that use the tax cloud calculator' do
+  it 'only calculates using tax cloud for orders that use the tax cloud calculator' do
     add_to_cart('RoR Mug')
     click_button 'Checkout'
 


### PR DESCRIPTION
https://github.com/solidusio-contrib/solidus_tax_cloud/pull/25 removed the word `should` from specs, which makes sense but had the effect of turning `should only calculate` to `onlies calculate`. This PR fixes that syntax to `only calculates`.