### PR TITLE
Handle combined Address first name and last name

### DIFF
--- a/spec/features/checkout_spec.rb
+++ b/spec/features/checkout_spec.rb
@@ -156,10 +156,10 @@ describe 'Checkout', js: true do
     # Case 7, Handling Errors).
     #
     # NOTE: In the API specs (from official TaxCloud Implementation Verification Guide), there is
-    # no shipping item sent to TaxCloud, and there is only a single $1.00 charge for the item.
+    # no shipping item sent to TaxCloud, and there is only a single $0.99 charge for the item.
     # In this integration test, Solidus will automatically send the shipping information, which
-    # results in a second $1.00 charge, for a total tax of $2.00.
-    expect(page).to have_content(/Sales Tax\s\$2.00/i)
+    # results in a second $0.99 charge, for a total tax of $1.98.
+    expect(page).to have_content(/Sales Tax\s\$1.98/i)
   end
 
   it 'TaxCloud Test Case 1b: Verify Address without error' do

--- a/spec/features/checkout_spec.rb
+++ b/spec/features/checkout_spec.rb
@@ -403,8 +403,13 @@ describe 'Checkout', js: true do
 
   def fill_in_address(address)
     fieldname = 'order_bill_address_attributes'
-    fill_in "#{fieldname}_firstname", with: address.first_name
-    fill_in "#{fieldname}_lastname", with: address.last_name
+    if Spree::Config.has_preference?(:use_combined_first_and_last_name_in_address) &&
+       Spree::Config.use_combined_first_and_last_name_in_address
+      fill_in "#{fieldname}_name", with: address.name
+    else
+      fill_in "#{fieldname}_firstname", with: address.first_name
+      fill_in "#{fieldname}_lastname", with: address.last_name
+    end
 
     fill_in "#{fieldname}_address1", with: address.address1
     fill_in "#{fieldname}_city", with: address.city

--- a/spec/features/checkout_spec.rb
+++ b/spec/features/checkout_spec.rb
@@ -405,6 +405,7 @@ describe 'Checkout', js: true do
     fieldname = 'order_bill_address_attributes'
     fill_in "#{fieldname}_firstname", with: address.first_name
     fill_in "#{fieldname}_lastname", with: address.last_name
+
     fill_in "#{fieldname}_address1", with: address.address1
     fill_in "#{fieldname}_city", with: address.city
     select address.country.name, from: "#{fieldname}_country_id"
@@ -426,94 +427,80 @@ describe 'Checkout', js: true do
   end
 
   def stock_location_address
-    Spree::Address.new(
-      firstname: 'Testing',
-      lastname: 'Location',
+    build(
+      :address,
       address1: '3121 W Government Way',
       city: 'Seattle',
       country: Spree::Country.find_by(name: 'United States of America'),
       state: Spree::State.find_by(abbr: 'WA'),
-      zipcode: '98199-1402',
-      phone: '(555) 5555-555'
+      zipcode: '98199-1402'
     )
   end
 
   def test_case_1a_address
-    Spree::Address.new(
-      firstname: 'John',
-      lastname: 'Doe',
+    build(
+      :address,
       address1: '1 3rd Street',
       city: 'Seattle',
       country: Spree::Country.find_by(name: 'United States of America'),
       state: Spree::State.find_by(abbr: 'WA'),
-      zipcode: '98001',
-      phone: '(555) 5555-555'
+      zipcode: '98001'
     )
   end
 
   def test_case_1b_address
-    Spree::Address.new(
-      firstname: 'John',
-      lastname: 'Doe',
+    build(
+      :address,
       address1: '16422 SE 128th St',
       city: 'Renton',
       country: Spree::Country.find_by(name: 'United States of America'),
       state: Spree::State.find_by(abbr: 'WA'),
-      zipcode: '98059',
-      phone: '(555) 5555-555'
+      zipcode: '98059'
     )
   end
 
   def test_case_2a_address
-    Spree::Address.new(
-      firstname: 'John',
-      lastname: 'Doe',
+    build(
+      :address,
       address1: '75 Rev Martin Luther King Jr Drive',
       city: 'St. Paul',
       country: Spree::Country.find_by(name: 'United States of America'),
       state: Spree::State.find_by(abbr: 'MN'),
-      zipcode: '55155',
-      phone: '(555) 5555-555'
+      zipcode: '55155'
     )
   end
   alias_method :test_case_2b_address, :test_case_2a_address
 
   def test_case_3_address
-    Spree::Address.new(
-      firstname: 'John',
-      lastname: 'Doe',
+    build(
+      :address,
       address1: '2300 N Lincoln Blvd',
       city: 'Oklahoma City',
       country: Spree::Country.where(name: 'United States of America').first,
       state: Spree::State.where(abbr: 'OK').first,
-      zipcode: '73105',
-      phone: '(555) 5555-555'
+      zipcode: '73105'
     )
   end
 
   def test_case_6_address
-    Spree::Address.new(
-      firstname: 'John',
-      lastname: 'Doe',
+    build(
+      :address,
       address1: '384 Northyards Blvd NW',
       city: 'Atlanta',
       country: Spree::Country.where(name: 'United States of America').first,
       state: Spree::State.where(abbr: 'GA').first,
-      zipcode: '30313',
-      phone: '(555) 5555-555'
+      zipcode: '30313'
     )
   end
 
   def alabama_address
-    alabama_address = Spree::Address.new(
-      firstname: 'John',
-      lastname: 'Doe',
+    build(
+      :address,
       address1: '143 Swan Street',
       city: 'Montgomery',
       country: Spree::Country.where(name: 'United States of America').first,
       state: Spree::State.where(name: 'Alabama').first,
-      zipcode: '36110',
-      phone: '(555) 5555-555'
+      zipcode: '36110'
     )
   end
 end

--- a/spec/models/tax_cloud_api_spec.rb
+++ b/spec/models/tax_cloud_api_spec.rb
@@ -29,7 +29,7 @@ describe 'Models' do
 
     expect(result.cart_items.size).to eq 1
     expect(result.cart_items.first.cart_item_index).to eq 0
-    expect(result.cart_items.first.tax_amount).to eq 1.0
+    expect(result.cart_items.first.tax_amount).to eq 0.99
   end
 
   it 'TaxCloud Test Case 1b: Verify Address without error' do


### PR DESCRIPTION
In solidusio/solidus#3524 we introduced a new preference that allows to use the combined version of first name and last name. 
This PR fixes  updates checkout feature specs to reflect this preference.

Once the split version will be deprecated and removed, we can probably also revert this commit and use the combined version only.