### PR TITLE
Bump tax_cloud to v0.6.0 to resolve rdi= attribute missing

### DIFF
--- a/solidus_tax_cloud.gemspec
+++ b/solidus_tax_cloud.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'savon', '~> 2.12.0'
   spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 4']
   spec.add_dependency 'solidus_support', '~> 0.5'
-  spec.add_dependency 'tax_cloud', '>= 0.3', '< 0.5'
+  spec.add_dependency 'tax_cloud', '~> 0.6.0'
 
   spec.add_development_dependency 'solidus_dev_support'
 end


### PR DESCRIPTION
Resolved rdi= missing attribute issue by updating tax_cloud gem to v0.6.0.